### PR TITLE
fix(gateway): pass through upstream error details in streaming SSE responses

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/src/jmunch_mcp/gateway/openai_route.py
+++ b/src/jmunch_mcp/gateway/openai_route.py
@@ -550,7 +550,7 @@ async def stream_chat_completions(
             log.warning("upstream %s %d: %s", spec.name, e.status, e.body[:500])
             err = make_error(UPSTREAM_ERROR, f"upstream {spec.name} returned {e.status}: {e.body[:300]}",
                              status=e.status)
-            return 502, encode_as_sse({"error": err})
+            return e.status, [b"data: " + json.dumps(err).encode("utf-8") + b"\n\n", b"data: [DONE]\n\n"]
 
         loop_result = await _verb_loop(
             first_response=first, working=working,
@@ -562,7 +562,7 @@ async def stream_chat_completions(
             err = make_error(UPSTREAM_ERROR,
                              f"upstream {spec.name} returned {loop_result.status}: {loop_result.body[:300]}",
                              status=loop_result.status)
-            return 502, encode_as_sse({"error": err})
+            return loop_result.status, [b"data: " + json.dumps(err).encode("utf-8") + b"\n\n", b"data: [DONE]\n\n"]
         final_response = loop_result
     finally:
         await upstream.close()


### PR DESCRIPTION
Streaming error handlers wrapped error dicts in `encode_as_sse()`, which only processes completion chunks. This produced empty SSE data chunks, causing the OpenAI SDK to raise `RuntimeError` without the actual error message.

**Before:**
- `return 502, encode_as_sse({"error": err})` → empty chunks, masked errors
- Status code always 502 regardless of actual upstream status

**After:**
- `return e.status, [b"data: " + json.dumps(err).encode() + b"\n\n", b"data: [DONE]\n\n"]` → proper SSE error with real status
- Upstream error details (e.g. 429 rate limit messages) visible to clients