### PR TITLE
fix(gateway): fix verb-loop follow-up 400/502 errors (Airrouter/litellm)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Replaces #4 with a clean single-commit branch.

The verb-loop follow-up calls were producing 400/502 errors against
litellm-backed providers (Airrouter). Root cause + fix details in the
commit message.