### PR TITLE
fix(gateway): preserve user-role message in verb-loop follow-ups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
_compact_base_messages strips the original user-role message when building
compact payloads for drill-in iterations, folding it into the system message
instead. Upstream providers using litellm (e.g. Airrouter) reject requests
that lack any user-role message. Restore the user-role message in compact
follow-ups so verb drill-in works against litellm backends.